### PR TITLE
Update README

### DIFF
--- a/crypto/ecies/README
+++ b/crypto/ecies/README
@@ -12,7 +12,7 @@ standards, and therefore doesn't support the full SEC 1 algorithm set.
 STATUS:
 
 ecies should be ready for use. The ASN.1 support is only complete so
-far as to supported the listed algorithms before.
+far as to support the listed algorithms previously listed.
 
 
 CAVEATS


### PR DESCRIPTION
"far as to supported the listed algorithms before" - This sentence seems slightly off grammatically. It would be clearer as: "far as to support the listed algorithms previously listed."